### PR TITLE
GameObject.DestroyImmediate used over GameObject.Destroy when needed

### DIFF
--- a/src/Robotlegs/Bender/Platforms/Unity/DependencyProviders/AbstractUnityComponentProvider.cs
+++ b/src/Robotlegs/Bender/Platforms/Unity/DependencyProviders/AbstractUnityComponentProvider.cs
@@ -84,21 +84,21 @@ namespace Robotlegs.Bender.DependencyProviders
 			return component;
 		}
 
-        public void RemoveComponent()
+		public void RemoveComponent()
 		{
 			if (destroyGameObjectWhenComplete && parentObject != null)
 			{
-                if (!Application.isPlaying)
-                    GameObject.DestroyImmediate(parentObject.gameObject);
-                else
-                    GameObject.Destroy(parentObject.gameObject);
+				if (!Application.isPlaying)
+					GameObject.DestroyImmediate(parentObject.gameObject);
+				else
+					GameObject.Destroy(parentObject.gameObject);
 			}
 			else
 			{
-                if(!Application.isPlaying)
-                    Component.DestroyImmediate(component);
-                else
-                    Component.Destroy(component);
+				if(!Application.isPlaying)
+					Component.DestroyImmediate(component);
+				else
+					Component.Destroy(component);
 			}
 			parentObject = null;
 			component = null;

--- a/src/Robotlegs/Bender/Platforms/Unity/DependencyProviders/AbstractUnityComponentProvider.cs
+++ b/src/Robotlegs/Bender/Platforms/Unity/DependencyProviders/AbstractUnityComponentProvider.cs
@@ -84,11 +84,14 @@ namespace Robotlegs.Bender.DependencyProviders
 			return component;
 		}
 
-		public void RemoveComponent()
+        public void RemoveComponent()
 		{
 			if (destroyGameObjectWhenComplete && parentObject != null)
 			{
-				GameObject.Destroy(parentObject.gameObject);
+                if (!Application.isPlaying)
+                    GameObject.DestroyImmediate(parentObject.gameObject);
+                else
+                    GameObject.Destroy(parentObject.gameObject);
 			}
 			else
 			{

--- a/src/Robotlegs/Bender/Platforms/Unity/Extensions/Mediation/Impl/UnityMediatorManager.cs
+++ b/src/Robotlegs/Bender/Platforms/Unity/Extensions/Mediation/Impl/UnityMediatorManager.cs
@@ -102,7 +102,10 @@ namespace Robotlegs.Bender.Platforms.Unity.Extensions.Mediation.Impl
 
 			if (mediatorAttach.Mediators.Length == 0) 
 			{
-				GameObject.Destroy (mediatorAttach);
+				if(!Application.isPlaying)
+				    GameObject.DestroyImmediate (mediatorAttach);
+                else
+                    GameObject.Destroy (mediatorAttach);
 				_viewMediatorAttachDictionary.Remove (view);
 			}
 		}

--- a/src/Robotlegs/Bender/Platforms/Unity/Extensions/Mediation/Impl/UnityMediatorManager.cs
+++ b/src/Robotlegs/Bender/Platforms/Unity/Extensions/Mediation/Impl/UnityMediatorManager.cs
@@ -99,13 +99,13 @@ namespace Robotlegs.Bender.Platforms.Unity.Extensions.Mediation.Impl
 			
 			MediatorAttach mediatorAttach = _viewMediatorAttachDictionary[view];
 			mediatorAttach.RemoveMediator (mediator);
-
+			
 			if (mediatorAttach.Mediators.Length == 0) 
 			{
 				if(!Application.isPlaying)
-				    GameObject.DestroyImmediate (mediatorAttach);
-                else
-                    GameObject.Destroy (mediatorAttach);
+					GameObject.DestroyImmediate (mediatorAttach);
+				else
+					GameObject.Destroy (mediatorAttach);
 				_viewMediatorAttachDictionary.Remove (view);
 			}
 		}


### PR DESCRIPTION
DestroyImmediate is now used when Application.isPlaying is false.
This solves errors that were occurring when unit tests were run in the editor.

Closes #13 