### PR TITLE
Feature/Inject into Hooks and Guards

### DIFF
--- a/src/Robotlegs/Bender/Framework/Impl/Guards.cs
+++ b/src/Robotlegs/Bender/Framework/Impl/Guards.cs
@@ -39,6 +39,10 @@ namespace Robotlegs.Bender.Framework.Impl
 				MethodInfo approveMethod = guardInstance.GetType().GetMethod("Approve");
 				if (approveMethod != null)
 				{
+					//Before we invoke Approve, inject any needed values
+					if (injector != null && guardInstance.GetType().IsClass)
+						injector.InjectInto(guardInstance);
+
 					if ((bool)approveMethod.Invoke (guardInstance, null) == false)
 						return false;
 				}

--- a/src/Robotlegs/Bender/Framework/Impl/Hooks.cs
+++ b/src/Robotlegs/Bender/Framework/Impl/Hooks.cs
@@ -42,7 +42,13 @@ namespace Robotlegs.Bender.Framework.Impl
 
 				MethodInfo hookMethod = hookInstance.GetType().GetMethod("Hook");
 				if (hookMethod != null)
+                {
+					//Before we invoke Hook, inject any needed values
+					if (injector != null && hookInstance.GetType().IsClass)
+						injector.InjectInto(hookInstance);
+
 					hookMethod.Invoke (hookInstance, null);
+                }
 				else
 					throw new Exception ("Invalid hook to apply");
 			}


### PR DESCRIPTION
Modified the `Guards` `Approve` method. Before invoking the `Approve` method on a `Guard` we now inject into it.

Did the same for `Hooks` `Apply` method. We inject before invoking the `Hook` method.

Resolves #3 